### PR TITLE
Add multiplier option to `typcsset-space` mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ $typecsset-base-line-height:    24px;
 
 ### `typecsset-space()`
 
-The `typecsset-space()` mixin simply drops a double amount of ‘spacing’ onto a given
-property, e.g. `padding`:
+The `typecsset-space()` mixin simply drops a user set amount of ‘spacing’ onto a given
+property (defaults to double spacing), e.g. `padding`:
 
 **Input:**
 
@@ -151,7 +151,7 @@ property, e.g. `padding`:
 $typecsset-base-line-height:    24px;
 
 .foo {
-    @include typecsset-space(margin-bottom);
+    @include typecsset-space(margin-bottom, 3);
 }
 ```
 
@@ -159,8 +159,8 @@ $typecsset-base-line-height:    24px;
 
 ```css
 .foo {
-    margin-bottom: 48px;
-    margin-bottom: 3rem;
+    margin-bottom: 72px;
+    margin-bottom: 4.5rem;
 }
 ```
 

--- a/typecsset.scss
+++ b/typecsset.scss
@@ -70,15 +70,15 @@ $typecsset-magic-ratio:         $typecsset-base-line-height / $typecsset-base-fo
 }
 
 // Space elements by an amount based on your magic number. Pass in the property
-// to be indented as a paramater, e.g.:
+// to be indented as a paramater and the number of lines to use as an optional paramater, e.g.:
 //
 // pre {
-//     @include typecsset-space(padding-left);
+//     @include typecsset-space(padding-left, 1);
 // }
 //
-@mixin typecsset-space($property) {
-    #{$property}: 2 * $typecsset-magic-number;
-    #{$property}: 2 * $typecsset-magic-ratio + rem;
+@mixin typecsset-space($property, $multiplier: 2) {
+    #{$property}: $multiplier * $typecsset-magic-number;
+    #{$property}: $multiplier * $typecsset-magic-ratio + rem;
 }
 
 // A small, internally-used function to remove the units from a given value.


### PR DESCRIPTION
Allows the `typecsset-space` mixin to optionally use any number of lines as its value, defaulting to 2.
