### PR TITLE
adds bower.json, fixes #3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "typecsset",
+  "version": "0.3.0",
+  "homepage": "http://csswizardry.com/typecsset/",
+  "authors": [
+    "Harry Roberts <harry@csswizardry.com>"
+  ],
+  "description": "A small Sass library for setting type on the web.",
+  "main": "typecsset.scss",
+  "keywords": [
+    "Sass",
+    "typeset",
+    "type",
+    "CSS",
+    "vertical",
+    "rhythm"
+  ],
+  "license": "Apache License 2.0"
+}


### PR DESCRIPTION
I'm with @faviouz that your repo should be on bower, so I created a sample `bower.json` for you. If you want to do it yourself, just install [bower](http://bower.io), and then type

```
bower init
```

in your local typecsset folder. You will see some prompts, which will fill out same `bower.json` ;-)

Once we have that file in the repo, we just have to register it with the package manager, like so:

```
bower register typecsset https://github.com/csswizardry/typecsset
```

Wishes,
Stefan
